### PR TITLE
Latest MARS sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id "com.diffplug.spotless" version "5.12.5"
+    id "com.diffplug.spotless" version "6.25.0"
     id 'java-library'
     id 'maven-publish'
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 group = 'com.elixir.mars'
-version = '0.0.1'
+version = '0.0.2-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -31,14 +31,14 @@ publishing {
     }
      repositories {
         mavenLocal()
-         maven {
-             name = "GitHubPackages"
-             url = uri("https://maven.pkg.github.com/elixir-europe/mars-repository-lib")
-             credentials {
-                 username = System.getenv("GITHUB_ACTOR")
-                 password = System.getenv("GITHUB_TOKEN")
-             }
-         }
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/elixir-europe/mars-repository-lib")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }
 

--- a/src/main/java/com/elixir/mars/repository/models/isa/Assay.java
+++ b/src/main/java/com/elixir/mars/repository/models/isa/Assay.java
@@ -19,5 +19,6 @@ public class Assay {
   public Materials materials;
   public ArrayList<ProcessSequence> processSequence;
   public ArrayList<DataFile> dataFiles;
+  public ArrayList<Comment> comments;
   public ArrayList<Object> unitCategories;
 }

--- a/src/main/java/com/elixir/mars/repository/models/isa/Category.java
+++ b/src/main/java/com/elixir/mars/repository/models/isa/Category.java
@@ -9,4 +9,6 @@ import lombok.experimental.FieldNameConstants;
 public class Category {
   @JsonProperty("@id")
   public String id;
+
+  public CharacteristicType characteristicType;
 }


### PR DESCRIPTION
There are some changes in the [MARS](https://github.com/elixir-europe/MARS/commits/main/repository-services/receipt) receipt package that are not set here in this repo.  

- Java is updated to version 17
- Some changes in models:
  - Assay
  - Category